### PR TITLE
Add a media query to make the menu bar responsive on smaller viewports

### DIFF
--- a/app/static/styles/main.css
+++ b/app/static/styles/main.css
@@ -231,3 +231,9 @@ a {
   box-shadow: 0 0 10px 5px white;
   color: rgb(238, 188, 76);
 }
+
+@media (max-width: 580px) {
+  .menu-container {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
- .menu-container's width is 100% if the screen's width is 580px or smaller